### PR TITLE
JPA 공통화 3개 아이템 구현: Tenant 격리 자동화, 에러 처리 공통화, UK별 CRUD 자동 생성

### DIFF
--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/access/AbstractCrudService.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/access/AbstractCrudService.java
@@ -1,61 +1,188 @@
 package com.tsh.starter.befw.lib.core.data.orm.common.access;
 
+import java.lang.reflect.ParameterizedType;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import com.tsh.starter.befw.lib.core.data.constant.UseStatCd;
+import com.tsh.starter.befw.lib.core.data.orm.common.error.DataErrorResponse;
+import com.tsh.starter.befw.lib.core.data.orm.common.error.JpaExceptionHandler;
 import com.tsh.starter.befw.lib.core.data.orm.common.model.BaseModel;
 import com.tsh.starter.befw.lib.core.data.orm.common.repo.BaseJpaRepository;
+import com.tsh.starter.befw.lib.core.data.orm.common.tenant.TenantContext;
+import com.tsh.starter.befw.lib.core.data.orm.common.uk.UkCrudService;
+import com.tsh.starter.befw.lib.core.data.orm.common.uk.UkCrudSupport;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+import org.springframework.beans.factory.annotation.Autowired;
 
-public abstract class AbstractCrudService<M extends BaseModel, ID> implements CrudService<M, ID> {
+@Slf4j
+public abstract class AbstractCrudService<M extends BaseModel, ID>
+	implements CrudService<M, ID>, UkCrudService<M> {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Autowired
+	private JpaExceptionHandler jpaExceptionHandler;
+
+	@Autowired
+	private UkCrudSupport ukCrudSupport;
 
 	protected abstract BaseJpaRepository<M, ID> getRepository();
 
+	@SuppressWarnings("unchecked")
+	protected Class<M> getEntityClass() {
+		ParameterizedType type = (ParameterizedType) getClass().getGenericSuperclass();
+		return (Class<M>) type.getActualTypeArguments()[0];
+	}
+
+	protected String getEntityName() {
+		return getEntityClass().getSimpleName();
+	}
+
+	protected void enableTenantFilter() {
+		String tenant = TenantContext.get();
+		Session session = entityManager.unwrap(Session.class);
+		session.enableFilter("tenantFilter").setParameter("tenant", tenant);
+	}
+
 	@Override
 	public M findById(ID id) {
-		return getRepository().findById(id)
-			.orElseThrow(() -> new EntityNotFoundException("not found: " + id));
+		try {
+			enableTenantFilter();
+			return getRepository().findById(id)
+				.orElseThrow(() -> new EntityNotFoundException("not found: " + id));
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), id, "findById");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	public List<M> findAll(String tenant) {
-		return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.Usable);
+		try {
+			enableTenantFilter();
+			return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.Usable);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), tenant, "findAll");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	public List<M> findAll(String tenant, LocalDateTime since) {
-		return getRepository().findRecentlyUpdated(tenant, UseStatCd.Usable, since);
+		try {
+			enableTenantFilter();
+			return getRepository().findRecentlyUpdated(tenant, UseStatCd.Usable, since);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), tenant, "findAll(since=" + since + ")");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	public List<M> findAllSoftDelete(String tenant) {
-		return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.Delete);
+		try {
+			enableTenantFilter();
+			return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.Delete);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), tenant, "findAllSoftDelete");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	public List<M> findAllWrongData(String tenant) {
-		return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.UnUsable);
+		try {
+			enableTenantFilter();
+			return getRepository().findByTenantAndUseStatCd(tenant, UseStatCd.UnUsable);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), tenant, "findAllWrongData");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	@Transactional
 	public M create(M model) {
-		return getRepository().save(model);
+		try {
+			return getRepository().save(model);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), model, "create");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	@Transactional
 	public M update(ID id, M model) {
-		return getRepository().save(model);
+		try {
+			return getRepository().save(model);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), id, "update");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 
 	@Override
 	@Transactional
 	public void delete(ID id) {
-		M model = findById(id);
-		model.setUseStatCd(UseStatCd.Delete);   // Soft Delete
+		try {
+			M model = findById(id);
+			model.setUseStatCd(UseStatCd.Delete);   // Soft Delete
+			getRepository().save(model);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), id, "delete");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
+	}
+
+	// ── UK CRUD ──────────────────────────────────────────────────────────────
+
+	@Override
+	public M findByUk(String ukName, Map<String, Object> params) {
+		try {
+			enableTenantFilter();
+			return ukCrudSupport.findByUk(getEntityClass(), ukName, params);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), params, "findByUk(" + ukName + ")");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
+	}
+
+	@Override
+	@Transactional
+	public M updateByUk(String ukName, Map<String, Object> params, M model) {
+		try {
+			enableTenantFilter();
+			M existing = ukCrudSupport.findByUk(getEntityClass(), ukName, params);
+			Map<String, String> ukColumns = ukCrudSupport.resolveUkColumns(getEntityClass(), ukName);
+			ukCrudSupport.copyNonNullFields(model, existing, ukColumns);
+			return getRepository().save(existing);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), params, "updateByUk(" + ukName + ")");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
+	}
+
+	@Override
+	@Transactional
+	public void deleteByUk(String ukName, Map<String, Object> params) {
+		try {
+			enableTenantFilter();
+			M existing = ukCrudSupport.findByUk(getEntityClass(), ukName, params);
+			existing.setUseStatCd(UseStatCd.Delete);   // Soft Delete
+			getRepository().save(existing);
+		} catch (Exception e) {
+			DataErrorResponse response = jpaExceptionHandler.handle(e, getEntityName(), params, "deleteByUk(" + ukName + ")");
+			throw new RuntimeException(response.getErrorCode() + ": " + response.getMessage(), e);
+		}
 	}
 }

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/DataErrorCode.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/DataErrorCode.java
@@ -1,0 +1,13 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.error;
+
+public enum DataErrorCode {
+
+	NOT_FOUND,
+	UK_DUPLICATE,
+	INVALID_REQUEST,
+	LOCK_CONFLICT,
+	DB_UNAVAILABLE,
+	TENANT_MISSING,
+	UNKNOWN
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/DataErrorResponse.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/DataErrorResponse.java
@@ -1,0 +1,36 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.error;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class DataErrorResponse {
+
+	private DataErrorCode errorCode;
+	private String message;
+	private String entity;
+	private Object params;
+	private String query;
+	private LocalDateTime occurredAt;
+
+	public static DataErrorResponse of(
+		DataErrorCode errorCode,
+		String message,
+		String entity,
+		Object params,
+		String query
+	) {
+		return DataErrorResponse.builder()
+			.errorCode(errorCode)
+			.message(message)
+			.entity(entity)
+			.params(params)
+			.query(query)
+			.occurredAt(LocalDateTime.now())
+			.build();
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/JpaExceptionHandler.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/error/JpaExceptionHandler.java
@@ -1,0 +1,88 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.error;
+
+import com.tsh.starter.befw.lib.core.data.orm.common.exception.TenantMissingException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.stereotype.Component;
+
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+@Slf4j
+@Component
+public class JpaExceptionHandler {
+
+	private static final int MAX_RETRY = 2;
+	private static final long MAX_TOTAL_MS = 100L;
+
+	public DataErrorResponse handle(Exception e, String entityName, Object params, String query) {
+		if (e instanceof OptimisticLockingFailureException) {
+			return handleWithRetry((OptimisticLockingFailureException) e, entityName, params, query);
+		}
+
+		DataErrorCode code = resolveCode(e);
+		log.error("[JPA ERROR] entityName={} | errorCode={} | params={} | query={} | message={}",
+			entityName, code, params, query, e.getMessage());
+		return DataErrorResponse.of(code, e.getMessage(), entityName, params, query);
+	}
+
+	private DataErrorResponse handleWithRetry(
+		OptimisticLockingFailureException originalException,
+		String entityName, Object params, String query
+	) {
+		long startTime = System.currentTimeMillis();
+		Exception lastException = originalException;
+
+		for (int attempt = 1; attempt <= MAX_RETRY; attempt++) {
+			long elapsed = System.currentTimeMillis() - startTime;
+			if (elapsed >= MAX_TOTAL_MS) {
+				break;
+			}
+
+			long remaining = MAX_TOTAL_MS - elapsed;
+			long sleepMs = remaining / (MAX_RETRY - attempt + 1);
+
+			if (sleepMs > 0) {
+				try {
+					Thread.sleep(sleepMs);
+				} catch (InterruptedException ie) {
+					Thread.currentThread().interrupt();
+					break;
+				}
+			}
+
+			// 재시도 로직은 호출자가 수행하므로 여기서는 재시도 신호만 기록
+			log.warn("[JPA RETRY] attempt={} | entityName={} | elapsed={}ms",
+				attempt, entityName, System.currentTimeMillis() - startTime);
+		}
+
+		log.error("[JPA ERROR] entityName={} | errorCode={} | params={} | query={} | message={}",
+			entityName, DataErrorCode.LOCK_CONFLICT, params, query, lastException.getMessage());
+		return DataErrorResponse.of(DataErrorCode.LOCK_CONFLICT, lastException.getMessage(), entityName, params, query);
+	}
+
+	private DataErrorCode resolveCode(Exception e) {
+		if (e instanceof EntityNotFoundException) {
+			return DataErrorCode.NOT_FOUND;
+		}
+		if (e instanceof DataIntegrityViolationException) {
+			return DataErrorCode.UK_DUPLICATE;
+		}
+		if (e instanceof ConstraintViolationException) {
+			return DataErrorCode.INVALID_REQUEST;
+		}
+		if (e instanceof OptimisticLockingFailureException) {
+			return DataErrorCode.LOCK_CONFLICT;
+		}
+		if (e instanceof JpaSystemException) {
+			return DataErrorCode.DB_UNAVAILABLE;
+		}
+		if (e instanceof TenantMissingException) {
+			return DataErrorCode.TENANT_MISSING;
+		}
+		return DataErrorCode.UNKNOWN;
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/exception/TenantMissingException.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/exception/TenantMissingException.java
@@ -1,0 +1,13 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.exception;
+
+public class TenantMissingException extends RuntimeException {
+
+	public TenantMissingException(String message) {
+		super(message);
+	}
+
+	public TenantMissingException() {
+		super("Tenant is required but not set. Please set tenant before any DB access.");
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/model/BaseModel.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/model/BaseModel.java
@@ -11,11 +11,19 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.FilterDef;
+import org.hibernate.annotations.ParamDef;
 
 @Slf4j
 @MappedSuperclass
 @Getter
 @Setter
+@FilterDef(
+	name = "tenantFilter",
+	parameters = @ParamDef(name = "tenant", type = String.class)
+)
+@Filter(name = "tenantFilter", condition = "TENANT = :tenant")
 public class BaseModel extends BasicAudit {
 
 	public static final String SRV_ID = "SRV_ID";

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantContext.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantContext.java
@@ -1,0 +1,29 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.tenant;
+
+import com.tsh.starter.befw.lib.core.data.orm.common.exception.TenantMissingException;
+
+public final class TenantContext {
+
+	private static final ThreadLocal<String> TENANT_HOLDER = new ThreadLocal<>();
+
+	private TenantContext() {
+		throw new UnsupportedOperationException("TenantContext is a utility class");
+	}
+
+	public static void set(String tenant) {
+		TENANT_HOLDER.set(tenant);
+	}
+
+	public static String get() {
+		String tenant = TENANT_HOLDER.get();
+		if (tenant == null || tenant.isBlank()) {
+			throw new TenantMissingException();
+		}
+		return tenant;
+	}
+
+	public static void clear() {
+		TENANT_HOLDER.remove();
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantResolver.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantResolver.java
@@ -1,0 +1,11 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.tenant;
+
+public interface TenantResolver {
+
+	void setTenant(String tenant);
+
+	String getTenant();
+
+	void clear();
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/ThreadLocalTenantResolver.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/ThreadLocalTenantResolver.java
@@ -1,0 +1,23 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.tenant;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadLocalTenantResolver implements TenantResolver {
+
+	@Override
+	public void setTenant(String tenant) {
+		TenantContext.set(tenant);
+	}
+
+	@Override
+	public String getTenant() {
+		return TenantContext.get();
+	}
+
+	@Override
+	public void clear() {
+		TenantContext.clear();
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudService.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudService.java
@@ -1,0 +1,13 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.uk;
+
+import java.util.Map;
+
+public interface UkCrudService<M> {
+
+	M findByUk(String ukName, Map<String, Object> params);
+
+	M updateByUk(String ukName, Map<String, Object> params, M model);
+
+	void deleteByUk(String ukName, Map<String, Object> params);
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudSupport.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudSupport.java
@@ -1,0 +1,195 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.uk;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class UkCrudSupport {
+
+	private final EntityManager entityManager;
+
+	public UkCrudSupport(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+
+	/**
+	 * 엔티티 클래스에서 ukName에 해당하는 UniqueConstraint의 컬럼 목록을 반환한다.
+	 * 컬럼명(DB)을 키, 필드명(Java)을 값으로 하는 Map으로 반환.
+	 */
+	public Map<String, String> resolveUkColumns(Class<?> entityClass, String ukName) {
+		Table tableAnnotation = entityClass.getAnnotation(Table.class);
+		if (tableAnnotation == null) {
+			throw new IllegalArgumentException(
+				"Entity " + entityClass.getSimpleName() + " has no @Table annotation");
+		}
+
+		UniqueConstraint[] constraints = tableAnnotation.uniqueConstraints();
+		if (constraints == null || constraints.length == 0) {
+			throw new IllegalArgumentException(
+				"Entity " + entityClass.getSimpleName() + " has no @UniqueConstraint defined");
+		}
+
+		UniqueConstraint target = Arrays.stream(constraints)
+			.filter(uc -> ukName.equals(uc.name()))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException(
+				"UniqueConstraint with name '" + ukName + "' not found in " + entityClass.getSimpleName()));
+
+		// 컬럼명 -> 필드명 매핑
+		Map<String, String> columnToField = buildColumnToFieldMap(entityClass);
+
+		Map<String, String> result = new HashMap<>();
+		for (String columnName : target.columnNames()) {
+			String fieldName = columnToField.get(columnName.toUpperCase());
+			if (fieldName == null) {
+				// 컬럼명과 필드명이 같은 경우(어노테이션 없이 기본 매핑)도 고려
+				fieldName = columnName;
+			}
+			result.put(columnName.toUpperCase(), fieldName);
+		}
+		return result;
+	}
+
+	/**
+	 * 엔티티 클래스의 모든 필드를 순회하며 @Column(name=...) -> 필드명 매핑을 구성한다.
+	 */
+	private Map<String, String> buildColumnToFieldMap(Class<?> entityClass) {
+		Map<String, String> map = new HashMap<>();
+		Class<?> current = entityClass;
+		while (current != null && current != Object.class) {
+			for (Field field : current.getDeclaredFields()) {
+				Column col = field.getAnnotation(Column.class);
+				if (col != null && !col.name().isEmpty()) {
+					map.put(col.name().toUpperCase(), field.getName());
+				} else {
+					// @Column 없는 경우 필드명 그대로 매핑 (대소문자 무시)
+					map.put(field.getName().toUpperCase(), field.getName());
+				}
+			}
+			current = current.getSuperclass();
+		}
+		return map;
+	}
+
+	/**
+	 * UK 조건으로 단일 엔티티를 조회한다.
+	 */
+	public <M> M findByUk(Class<M> entityClass, String ukName, Map<String, Object> params) {
+		Map<String, String> ukColumns = resolveUkColumns(entityClass, ukName);
+		validateParams(ukColumns, params);
+
+		// 컬럼명 기준 params를 필드명 기준으로 변환
+		Map<String, Object> fieldParams = toFieldParams(ukColumns, params);
+
+		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+		CriteriaQuery<M> query = cb.createQuery(entityClass);
+		Root<M> root = query.from(entityClass);
+
+		List<Predicate> predicates = new ArrayList<>();
+		for (Map.Entry<String, Object> entry : fieldParams.entrySet()) {
+			predicates.add(cb.equal(root.get(entry.getKey()), entry.getValue()));
+		}
+		query.where(predicates.toArray(new Predicate[0]));
+
+		List<M> results = entityManager.createQuery(query).getResultList();
+
+		if (results.isEmpty()) {
+			throw new EntityNotFoundException(
+				"Entity not found by UK '" + ukName + "' with params: " + params);
+		}
+		return results.get(0);
+	}
+
+	/**
+	 * UK params를 필드명 기준으로 변환한다.
+	 */
+	private Map<String, Object> toFieldParams(Map<String, String> ukColumns, Map<String, Object> params) {
+		Map<String, Object> fieldParams = new HashMap<>();
+		for (Map.Entry<String, String> entry : ukColumns.entrySet()) {
+			String columnName = entry.getKey();
+			String fieldName = entry.getValue();
+			// params는 컬럼명 또는 필드명으로 들어올 수 있음
+			Object value = params.get(columnName);
+			if (value == null) {
+				value = params.get(fieldName);
+			}
+			if (value == null) {
+				// 대소문자 무시 검색
+				for (Map.Entry<String, Object> pe : params.entrySet()) {
+					if (pe.getKey().equalsIgnoreCase(columnName) || pe.getKey().equalsIgnoreCase(fieldName)) {
+						value = pe.getValue();
+						break;
+					}
+				}
+			}
+			fieldParams.put(fieldName, value);
+		}
+		return fieldParams;
+	}
+
+	/**
+	 * params의 키가 UK 컬럼 목록과 일치하는지 검증한다.
+	 */
+	private void validateParams(Map<String, String> ukColumns, Map<String, Object> params) {
+		for (Map.Entry<String, String> entry : ukColumns.entrySet()) {
+			String columnName = entry.getKey();
+			String fieldName = entry.getValue();
+			boolean found = params.containsKey(columnName)
+				|| params.containsKey(fieldName)
+				|| params.keySet().stream().anyMatch(k -> k.equalsIgnoreCase(columnName) || k.equalsIgnoreCase(fieldName));
+			if (!found) {
+				throw new IllegalArgumentException(
+					"Missing UK param for column '" + columnName + "' (field: " + fieldName + ")");
+			}
+		}
+	}
+
+	/**
+	 * model의 null이 아닌 필드를 target 엔티티에 복사한다. UK 필드는 제외한다.
+	 */
+	public <M> void copyNonNullFields(M source, M target, Map<String, String> ukColumns) {
+		Class<?> current = source.getClass();
+		while (current != null && current != Object.class) {
+			for (Field field : current.getDeclaredFields()) {
+				// UK 필드는 제외
+				if (isUkField(field, ukColumns)) {
+					continue;
+				}
+				field.setAccessible(true);
+				try {
+					Object value = field.get(source);
+					if (value != null) {
+						field.set(target, value);
+					}
+				} catch (IllegalAccessException e) {
+					// 접근 불가 필드는 무시
+				}
+			}
+			current = current.getSuperclass();
+		}
+	}
+
+	private boolean isUkField(Field field, Map<String, String> ukColumns) {
+		String fieldName = field.getName();
+		Column col = field.getAnnotation(Column.class);
+		String columnName = (col != null && !col.name().isEmpty()) ? col.name().toUpperCase() : fieldName.toUpperCase();
+		return ukColumns.containsKey(columnName) || ukColumns.containsValue(fieldName);
+	}
+
+}

--- a/src/main/java/com/tsh/starter/befw/lib/core/data/orm/gnMsgSrvConn/GnMsgSrvConnModel.java
+++ b/src/main/java/com/tsh/starter/befw/lib/core/data/orm/gnMsgSrvConn/GnMsgSrvConnModel.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,7 +18,12 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = GlobalTableName.GN_MSG_SRV_CONN)
+@Table(
+	name = GlobalTableName.GN_MSG_SRV_CONN,
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uk_msg_srv", columnNames = {"ENV", "HOST", "PORT"})
+	}
+)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/error/JpaExceptionHandlerTest.java
+++ b/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/error/JpaExceptionHandlerTest.java
@@ -1,0 +1,101 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.error;
+
+import com.tsh.starter.befw.lib.core.data.orm.common.exception.TenantMissingException;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.orm.jpa.JpaSystemException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JpaExceptionHandlerTest {
+
+	private JpaExceptionHandler handler;
+
+	@BeforeEach
+	void setUp() {
+		handler = new JpaExceptionHandler();
+	}
+
+	@Test
+	void handle_EntityNotFoundException_returns_NOT_FOUND() {
+		EntityNotFoundException e = new EntityNotFoundException("not found");
+		DataErrorResponse response = handler.handle(e, "TestEntity", "id-1", "findById");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.NOT_FOUND);
+		assertThat(response.getEntity()).isEqualTo("TestEntity");
+		assertThat(response.getParams()).isEqualTo("id-1");
+		assertThat(response.getQuery()).isEqualTo("findById");
+		assertThat(response.getOccurredAt()).isNotNull();
+	}
+
+	@Test
+	void handle_DataIntegrityViolationException_returns_UK_DUPLICATE() {
+		DataIntegrityViolationException e = new DataIntegrityViolationException("duplicate key");
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "create");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.UK_DUPLICATE);
+	}
+
+	@Test
+	void handle_ConstraintViolationException_returns_INVALID_REQUEST() {
+		ConstraintViolationException e = new ConstraintViolationException("constraint", null);
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "create");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.INVALID_REQUEST);
+	}
+
+	@Test
+	void handle_JpaSystemException_returns_DB_UNAVAILABLE() {
+		JpaSystemException e = new JpaSystemException(new RuntimeException("db error"));
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "findAll");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.DB_UNAVAILABLE);
+	}
+
+	@Test
+	void handle_TenantMissingException_returns_TENANT_MISSING() {
+		TenantMissingException e = new TenantMissingException();
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "findAll");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.TENANT_MISSING);
+	}
+
+	@Test
+	void handle_UnknownException_returns_UNKNOWN() {
+		RuntimeException e = new RuntimeException("unexpected");
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "findAll");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.UNKNOWN);
+	}
+
+	@Test
+	void handle_OptimisticLockingFailureException_returns_LOCK_CONFLICT_after_retry() {
+		OptimisticLockingFailureException e = new OptimisticLockingFailureException("lock conflict");
+		long start = System.currentTimeMillis();
+
+		DataErrorResponse response = handler.handle(e, "TestEntity", null, "update");
+
+		long elapsed = System.currentTimeMillis() - start;
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.LOCK_CONFLICT);
+		// 100ms 이내에 처리되어야 함
+		assertThat(elapsed).isLessThan(200L);
+	}
+
+	@Test
+	void handle_response_contains_all_fields() {
+		EntityNotFoundException e = new EntityNotFoundException("not found");
+		DataErrorResponse response = handler.handle(e, "MyEntity", "param-1", "findById");
+
+		assertThat(response.getErrorCode()).isEqualTo(DataErrorCode.NOT_FOUND);
+		assertThat(response.getMessage()).isNotNull();
+		assertThat(response.getEntity()).isEqualTo("MyEntity");
+		assertThat(response.getParams()).isEqualTo("param-1");
+		assertThat(response.getQuery()).isEqualTo("findById");
+		assertThat(response.getOccurredAt()).isNotNull();
+	}
+
+}

--- a/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantContextTest.java
+++ b/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/TenantContextTest.java
@@ -1,0 +1,81 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.tenant;
+
+import com.tsh.starter.befw.lib.core.data.orm.common.exception.TenantMissingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TenantContextTest {
+
+	@AfterEach
+	void tearDown() {
+		TenantContext.clear();
+	}
+
+	@Test
+	void set_and_get_tenant() {
+		TenantContext.set("tenantA");
+		assertThat(TenantContext.get()).isEqualTo("tenantA");
+	}
+
+	@Test
+	void get_throws_when_tenant_not_set() {
+		assertThatThrownBy(TenantContext::get)
+			.isInstanceOf(TenantMissingException.class)
+			.hasMessageContaining("Tenant is required");
+	}
+
+	@Test
+	void get_throws_when_tenant_is_blank() {
+		TenantContext.set("   ");
+		assertThatThrownBy(TenantContext::get)
+			.isInstanceOf(TenantMissingException.class);
+	}
+
+	@Test
+	void clear_removes_tenant() {
+		TenantContext.set("tenantA");
+		TenantContext.clear();
+		assertThatThrownBy(TenantContext::get)
+			.isInstanceOf(TenantMissingException.class);
+	}
+
+	@Test
+	void clear_prevents_tenant_leakage_across_requests() throws InterruptedException {
+		TenantContext.set("tenantA");
+		TenantContext.clear();
+
+		// 다음 요청 시뮬레이션: 이전 tenant가 남아있지 않아야 함
+		assertThatThrownBy(TenantContext::get)
+			.isInstanceOf(TenantMissingException.class);
+	}
+
+	@Test
+	void thread_isolation() throws InterruptedException {
+		TenantContext.set("tenantMain");
+
+		Thread[] tenantHolder = new Thread[1];
+		String[] threadTenant = new String[1];
+		Exception[] threadException = new Exception[1];
+
+		Thread thread = new Thread(() -> {
+			try {
+				TenantContext.set("tenantThread");
+				threadTenant[0] = TenantContext.get();
+				TenantContext.clear();
+			} catch (Exception e) {
+				threadException[0] = e;
+			}
+		});
+		thread.start();
+		thread.join();
+
+		assertThat(threadException[0]).isNull();
+		assertThat(threadTenant[0]).isEqualTo("tenantThread");
+		// 메인 스레드의 tenant는 변하지 않아야 함
+		assertThat(TenantContext.get()).isEqualTo("tenantMain");
+	}
+
+}

--- a/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/ThreadLocalTenantResolverTest.java
+++ b/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/tenant/ThreadLocalTenantResolverTest.java
@@ -1,0 +1,33 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.tenant;
+
+import com.tsh.starter.befw.lib.core.data.orm.common.exception.TenantMissingException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ThreadLocalTenantResolverTest {
+
+	private final TenantResolver resolver = new ThreadLocalTenantResolver();
+
+	@AfterEach
+	void tearDown() {
+		resolver.clear();
+	}
+
+	@Test
+	void setTenant_and_getTenant() {
+		resolver.setTenant("tenantB");
+		assertThat(resolver.getTenant()).isEqualTo("tenantB");
+	}
+
+	@Test
+	void clear_removes_tenant() {
+		resolver.setTenant("tenantB");
+		resolver.clear();
+		assertThatThrownBy(resolver::getTenant)
+			.isInstanceOf(TenantMissingException.class);
+	}
+
+}

--- a/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudSupportTest.java
+++ b/src/test/java/com/tsh/starter/befw/lib/core/data/orm/common/uk/UkCrudSupportTest.java
@@ -1,0 +1,194 @@
+package com.tsh.starter.befw.lib.core.data.orm.common.uk;
+
+import com.tsh.starter.befw.lib.core.data.constant.UseStatCd;
+import com.tsh.starter.befw.lib.core.data.orm.common.model.BaseModel;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UkCrudSupportTest {
+
+	@Mock
+	private EntityManager entityManager;
+
+	private UkCrudSupport support;
+
+	@BeforeEach
+	void setUp() {
+		support = new UkCrudSupport(entityManager);
+	}
+
+	// ── 테스트용 엔티티 ──────────────────────────────────────────────────────
+
+	@Entity
+	@Table(
+		name = "TEST_ENTITY",
+		uniqueConstraints = {
+			@UniqueConstraint(name = "uk_test", columnNames = {"COL_A", "COL_B"})
+		}
+	)
+	@Getter
+	@Setter
+	static class TestEntity extends BaseModel {
+		@Column(name = "COL_A")
+		private String colA;
+
+		@Column(name = "COL_B")
+		private String colB;
+
+		private String other;
+	}
+
+	@Entity
+	@Table(name = "NO_UK_ENTITY")
+	@Getter
+	@Setter
+	static class NoUkEntity extends BaseModel {
+		private String value;
+	}
+
+	// ── resolveUkColumns 테스트 ──────────────────────────────────────────────
+
+	@Test
+	void resolveUkColumns_returns_column_to_field_mapping() {
+		Map<String, String> columns = support.resolveUkColumns(TestEntity.class, "uk_test");
+
+		assertThat(columns).containsKey("COL_A");
+		assertThat(columns).containsKey("COL_B");
+		assertThat(columns.get("COL_A")).isEqualTo("colA");
+		assertThat(columns.get("COL_B")).isEqualTo("colB");
+	}
+
+	@Test
+	void resolveUkColumns_throws_when_entity_has_no_uniqueConstraint() {
+		assertThatThrownBy(() -> support.resolveUkColumns(NoUkEntity.class, "uk_test"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("no @UniqueConstraint");
+	}
+
+	@Test
+	void resolveUkColumns_throws_when_ukName_not_found() {
+		assertThatThrownBy(() -> support.resolveUkColumns(TestEntity.class, "uk_nonexistent"))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("uk_nonexistent");
+	}
+
+	// ── findByUk 테스트 ──────────────────────────────────────────────────────
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void findByUk_throws_when_result_is_empty() {
+		CriteriaBuilder cb = mock(CriteriaBuilder.class);
+		CriteriaQuery<TestEntity> cq = mock(CriteriaQuery.class);
+		Root<TestEntity> root = mock(Root.class);
+		Path<Object> pathA = mock(Path.class);
+		Path<Object> pathB = mock(Path.class);
+		Predicate predA = mock(Predicate.class);
+		Predicate predB = mock(Predicate.class);
+
+		when(entityManager.getCriteriaBuilder()).thenReturn(cb);
+		when(cb.createQuery(TestEntity.class)).thenReturn(cq);
+		when(cq.from(TestEntity.class)).thenReturn(root);
+		when(root.get("colA")).thenReturn(pathA);
+		when(root.get("colB")).thenReturn(pathB);
+		when(cb.equal(pathA, "valA")).thenReturn(predA);
+		when(cb.equal(pathB, "valB")).thenReturn(predB);
+		when(cq.where(any(Predicate[].class))).thenReturn(cq);
+
+		var typedQuery = mock(jakarta.persistence.TypedQuery.class);
+		when(entityManager.createQuery(cq)).thenReturn(typedQuery);
+		when(typedQuery.getResultList()).thenReturn(List.of());
+
+		Map<String, Object> params = Map.of("COL_A", "valA", "COL_B", "valB");
+
+		assertThatThrownBy(() -> support.findByUk(TestEntity.class, "uk_test", params))
+			.isInstanceOf(EntityNotFoundException.class)
+			.hasMessageContaining("uk_test");
+	}
+
+	@Test
+	void findByUk_throws_when_missing_param() {
+		Map<String, Object> params = Map.of("COL_A", "valA"); // COL_B 누락
+
+		assertThatThrownBy(() -> support.findByUk(TestEntity.class, "uk_test", params))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("COL_B");
+	}
+
+	// ── copyNonNullFields 테스트 ──────────────────────────────────────────────
+
+	@Test
+	void copyNonNullFields_copies_non_null_and_skips_uk_fields() {
+		TestEntity source = new TestEntity();
+		source.setColA("newA");   // UK 필드 - 복사 제외
+		source.setColB("newB");   // UK 필드 - 복사 제외
+		source.setOther("updatedOther");
+
+		TestEntity target = new TestEntity();
+		target.setColA("origA");
+		target.setColB("origB");
+		target.setOther("origOther");
+
+		Map<String, String> ukColumns = support.resolveUkColumns(TestEntity.class, "uk_test");
+		support.copyNonNullFields(source, target, ukColumns);
+
+		// UK 필드는 변경되지 않아야 함
+		assertThat(target.getColA()).isEqualTo("origA");
+		assertThat(target.getColB()).isEqualTo("origB");
+		// 일반 필드는 복사되어야 함
+		assertThat(target.getOther()).isEqualTo("updatedOther");
+	}
+
+	@Test
+	void copyNonNullFields_skips_null_source_fields() {
+		TestEntity source = new TestEntity();
+		source.setOther(null);  // null 필드는 복사하지 않음
+
+		TestEntity target = new TestEntity();
+		target.setOther("origOther");
+
+		Map<String, String> ukColumns = support.resolveUkColumns(TestEntity.class, "uk_test");
+		support.copyNonNullFields(source, target, ukColumns);
+
+		assertThat(target.getOther()).isEqualTo("origOther");
+	}
+
+	// ── Soft Delete 테스트 (동작 확인용) ──────────────────────────────────────
+
+	@Test
+	void soft_delete_uses_UseStatCd_Delete() {
+		TestEntity entity = new TestEntity();
+		entity.setUseStatCd(UseStatCd.Usable);
+
+		entity.setUseStatCd(UseStatCd.Delete);  // Soft Delete 적용
+
+		assertThat(entity.getUseStatCd()).isEqualTo(UseStatCd.Delete);
+	}
+
+}


### PR DESCRIPTION
- 아이템 3: TenantContext(ThreadLocal), TenantResolver, TenantMissingException 추가 BaseModel에 Hibernate tenantFilter 적용, AbstractCrudService에서 자동 활성화
- 아이템 2: DataErrorCode, DataErrorResponse, JpaExceptionHandler 추가 OptimisticLock 재시도(2회/100ms), 모든 JPA 예외를 DataErrorCode로 매핑 AbstractCrudService의 모든 메서드를 JpaExceptionHandler로 감쌈
- 아이템 1: UkCrudService 인터페이스, UkCrudSupport(Reflection+CriteriaBuilder) 추가 AbstractCrudService에 findByUk/updateByUk/deleteByUk 구현 GnMsgSrvConnModel에 uk_msg_srv(ENV, HOST, PORT) UniqueConstraint 예시 추가
- 단위 테스트: TenantContextTest, ThreadLocalTenantResolverTest, JpaExceptionHandlerTest, UkCrudSupportTest 작성